### PR TITLE
Avoid outgoing HTTP request at startup

### DIFF
--- a/models.py
+++ b/models.py
@@ -5,7 +5,8 @@ import torch
 # Initialize the tagger
 device = torch.device("cpu")  # CPU
 tagger_model: pos.Tagger = torch.hub.load(
-    repo_or_dir="cadia-lvl/POS",
+    repo_or_dir="cadia-lvl/POS:master",
+    skip_validation=True,
     model="tag",
     device=device,
     force_reload=False,


### PR DESCRIPTION
When presented with a plain `username/reponame` model name, `torch.hub.load` needs to make an outgoing HTTP request to GitHub to query whether the default branch on that repo is named `master` or `main`, in order to determine whether it has the model cached locally.  This PR makes us ask explicitly for `master`, and skips other validation checks at model load time, in order to allow it to just use the locally cached model without having to check with GitHub first.

Aside from saving a round trip, this allows the container to start correctly when it is run in a network with restricted egress (such as the ELG cluster).